### PR TITLE
Fix Grafana secret

### DIFF
--- a/monitoring/grafana-secret.yaml
+++ b/monitoring/grafana-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-prometheus-stack-grafana
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/managed-by: fluxcd
+    app.kubernetes.io/component: monitoring
+    app: grafana
+    release: kube-prometheus-stack
+
+type: Opaque
+data:
+  admin-user: YWRtaW4=
+  admin-password: cHJvbS1vcGVyYXRvcg==

--- a/monitoring/kustomization.yaml
+++ b/monitoring/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - helmrepository.yaml
   - helmrelease.yaml
+  - grafana-secret.yaml


### PR DESCRIPTION
## Summary
- add Grafana admin secret so helm chart can start
- reference secret from monitoring kustomization

## Testing
- `kustomize build monitoring` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb065f5ac8320814904f71cff406d