### PR TITLE
Add ingress for monitoring stack

### DIFF
--- a/monitoring/helmrelease.yaml
+++ b/monitoring/helmrelease.yaml
@@ -19,6 +19,22 @@ spec:
       adminPassword: prom-operator
       service:
         type: ClusterIP
+      ingress:
+        enabled: true
+        hosts:
+          - grafana.local
+        tls:
+          - secretName: grafana-tls
+            hosts:
+              - grafana.local
     prometheus:
       service:
         type: ClusterIP
+      ingress:
+        enabled: true
+        hosts:
+          - prometheus.local
+        tls:
+          - secretName: prometheus-tls
+            hosts:
+              - prometheus.local


### PR DESCRIPTION
## Summary
- enable ingress for Grafana and Prometheus via Helm values

## Testing
- `yamllint .` *(fails: many indentation and line-length errors)*

------
https://chatgpt.com/codex/tasks/task_e_684fb4124fb48320a07f7cc6f40c3406